### PR TITLE
DOC-78 Fix for valid response with errors:null

### DIFF
--- a/lib/wsd.js
+++ b/lib/wsd.js
@@ -117,12 +117,16 @@ exports.diagram_url = function diagram_url(description, style, format, cb) {
                 cb("JSON Syntax error: " + e.message);
                 return;
             }
-            if (!jres.errors) {
-                cb("Invalid JSON response: " + jres);
+
+            var errors = jres.errors;
+            if (errors && errors.length > 0) {
+                cb(errors);
+                return;
             }
 
-            if (jres.errors.length > 0) {
-                cb(jres.errors);
+            if (!jres.img) {
+                cb("JSON response does not contain an img: " + buf);
+                return;
             }
 
             cb(null, exports.root + "/" + jres.img);


### PR DESCRIPTION
- if there are errors it should stop execution.
- check if a valid response contains an img, errors are irrelevant